### PR TITLE
Clean up index.php

### DIFF
--- a/get/cssjs/index/appbar.js
+++ b/get/cssjs/index/appbar.js
@@ -1,0 +1,62 @@
+$(function() {
+  $(window)
+    .resize(
+      _.debounce(function() {
+        $("body").height(window.innerHeight);
+      })
+    )
+    .trigger("resize");
+  $("#join").click(function() {
+    if (
+      confirm(
+        "This will set a cookie to identify your account. You must be 16 or over to join TopAnswers."
+      )
+    ) {
+      $.post({
+        url: "//post.topanswers.xyz/profile",
+        data: { action: "new" },
+        async: false,
+        xhrFields: { withCredentials: true },
+      })
+        .done(function(r) {
+          alert(
+            "This login key should be kept confidential, just like a password.\nTo ensure continued access to your account, please record your key somewhere safe:\n\n" +
+              r
+          );
+          location.reload(true);
+        })
+        .fail(function(r) {
+          alert(
+            r.status === 429
+              ? "Rate limit hit, please try again later"
+              : responseText
+          );
+          location.reload(true);
+        });
+    }
+  });
+  $("#link").click(function() {
+    var pin = prompt("Enter PIN (or login key) from account profile");
+    if (pin !== null) {
+      $.post({
+        url: "//post.topanswers.xyz/profile",
+        data: { action: "link", link: pin },
+        async: false,
+        xhrFields: { withCredentials: true },
+      })
+        .fail(function(r) {
+          alert(r.responseText);
+        })
+        .done(function() {
+          location.reload(true);
+        });
+    }
+  });
+  $("#community").change(function() {
+    window.location =
+      "/" +
+      $(this)
+        .find(":selected")
+        .attr("data-name");
+  });
+});

--- a/get/cssjs/index/style.css
+++ b/get/cssjs/index/style.css
@@ -1,0 +1,16 @@
+html { box-sizing: border-box; font-family: source-sans-pro, serif; font-size: 16px; }
+body { display: flex; flex-direction: column; background: lightgrey; }
+html, body { height: 100vh; overflow: hidden; margin: 0; padding: 0; }
+footer, footer>div { display: flex; min-width: 0; overflow: hidden; align-items: center; }
+footer { min-height: 30px; flex: 0 0 auto; flex-wrap: wrap; justify-content: space-between; font-size: 14px; background: rgb(var(--rgb-dark)); color: rgb(var(--rgb-light)); border-top: 2px solid black; }
+footer a, footer .element a, footer a.element { color: rgb(var(--rgb-light)); }
+main { flex: 1 1 auto; overflow: auto; scroll-behavior: smooth; }
+main>div { background: white; flex: 1 1 auto; margin: 5vh 20vw; padding: 1px 24px; border-radius: 3px; }
+
+.icon { width: 20px; height: 20px; display: block; margin: 1px; border-radius: 2px; background: rgb(var(--rgb-dark)); }
+.communities { display: flex; flex-wrap: wrap; margin: 16px 0; margin-top: -24px; }
+.communities>a { border: 3px solid rgb(var(--rgb-mid)); border-radius: 6px; text-decoration: none; color: rgb(var(--rgb-light)); background: rgb(var(--rgb-dark)); padding: 8px 16px; font-size: 24px; margin: 8px; }
+
+@media (max-width: 576px){
+    main>div { margin: 16px 16px; }
+}

--- a/get/index.php
+++ b/get/index.php
@@ -25,24 +25,7 @@ extract(cdb("select account_id from one"));
   
   <script src="/lib/lodash.js"></script>
   <script src="/lib/jquery.js"></script>
-  <script>
-    $(function(){
-      $(window).resize(_.debounce(function(){ $('body').height(window.innerHeight); })).trigger('resize');
-      $('#join').click(function(){
-        if(confirm('This will set a cookie to identify your account. You must be 16 or over to join TopAnswers.')){
-          $.post({ url: '//post.topanswers.xyz/profile', data: { action: 'new' }, async: false, xhrFields: { withCredentials: true } }).done(function(r){
-            alert('This login key should be kept confidential, just like a password.\nTo ensure continued access to your account, please record your key somewhere safe:\n\n'+r);
-            location.reload(true);
-          }).fail(function(r){
-            alert((r.status)===429?'Rate limit hit, please try again later':responseText);
-            location.reload(true);
-          });
-        }
-      });
-      $('#link').click(function(){ var pin = prompt('Enter PIN (or login key) from account profile'); if(pin!==null) { $.post({ url: '//post.topanswers.xyz/profile', data: { action: 'link', link: pin }, async: false, xhrFields: { withCredentials: true } }).fail(function(r){ alert(r.responseText); }).done(function(){ location.reload(true); }); } });
-      $('#community').change(function(){ window.location = '/'+$(this).find(':selected').attr('data-name'); });
-    });
-  </script>
+  <script src="/cssjs/index/appbar.js"></script>
   <title>TopAnswers — Building a Library of Knowledge for the Internet</title>
 </head>
 <body>

--- a/get/index.php
+++ b/get/index.php
@@ -21,24 +21,8 @@ extract(cdb("select account_id from one"));
   <link rel="icon" href="/favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="/global.css">
   <link rel="stylesheet" href="/header.css">
-  <style>
-    html { box-sizing: border-box; font-family: source-sans-pro, serif; font-size: 16px; }
-    body { display: flex; flex-direction: column; background: lightgrey; }
-    html, body { height: 100vh; overflow: hidden; margin: 0; padding: 0; }
-    footer, footer>div { display: flex; min-width: 0; overflow: hidden; align-items: center; }
-    footer { min-height: 30px; flex: 0 0 auto; flex-wrap: wrap; justify-content: space-between; font-size: 14px; background: rgb(var(--rgb-dark)); color: rgb(var(--rgb-light)); border-top: 2px solid black; }
-    footer a, footer .element a, footer a.element { color: rgb(var(--rgb-light)); }
-    main { flex: 1 1 auto; overflow: auto; scroll-behavior: smooth; }
-    main>div { background: white; flex: 1 1 auto; margin: 5vh 20vw; padding: 1px 24px; border-radius: 3px; }
-
-    .icon { width: 20px; height: 20px; display: block; margin: 1px; border-radius: 2px; background: rgb(var(--rgb-dark)); }
-    .communities { display: flex; flex-wrap: wrap; margin: 16px 0; margin-top: -24px; }
-    .communities>a { border: 3px solid rgb(var(--rgb-mid)); border-radius: 6px; text-decoration: none; color: rgb(var(--rgb-light)); background: rgb(var(--rgb-dark)); padding: 8px 16px; font-size: 24px; margin: 8px; }
-
-    @media (max-width: 576px){
-      main>div { margin: 16px 16px; }
-    }
-  </style>
+  <link rel="stylesheet" href="/cssjs/index/style.css">
+  
   <script src="/lib/lodash.js"></script>
   <script src="/lib/jquery.js"></script>
   <script>

--- a/get/index.php
+++ b/get/index.php
@@ -53,11 +53,11 @@ function getPrivateCommunities() {
       <span class='element'>TopAnswers</span>
     </div>
     <div>
-      <?if($auth){?>
+      <? if ($auth) { ?>
         <a class="frame" href="/profile?community=meta"><img class="icon" src="/identicon?id=<?=$account_id?>"></a>
-      <?}else{?>
+      <? } else { ?>
         <span class="element"><input id="join" type="button" value="join"> or <input id="link" type="button" value="log in"></span>
-      <?}?>
+      <? } ?>
     </div>
   </header>
   <main>
@@ -66,16 +66,16 @@ function getPrivateCommunities() {
       <div class="communities">
         <? foreach(getPublicCommunities() as $r) { extract($r); ?>
           <a href="/<?=$community_name?>" style="--rgb-dark: <?=$community_rgb_dark?>; --rgb-mid: <?=$community_rgb_mid?>; --rgb-light: <?=$community_rgb_light?>;"><?=$community_display_name?></a>
-        <?}?>
+        <? } ?>
       </div>
       <?if (hasPrivateCommunities()) { ?>
         <h1>Coming Soon:</h1>
         <div class="communities">
           <? foreach(getPrivateCommunities() as $r) { extract($r); ?>
             <a href="/<?=$community_name?>" style="--rgb-dark: <?=$community_rgb_dark?>; --rgb-mid: <?=$community_rgb_mid?>; --rgb-light: <?=$community_rgb_light?>;"><?=$community_display_name?></a>
-          <?}?>
+          <? } ?>
         </div>
-      <?}?>
+      <? } ?>
     </div>
     <div style="--rgb-dark: 0,0,240;">
     <h1>Join TopAnswers, and help build a lasting library of knowledge.</h1>


### PR DESCRIPTION
The idea is that we 

- remove PHP logic from the front-end code as much as possible
  * to pave the way for unit testing these PHP functions
- move asset files (css, js) to their files so we can
  * make use of browser caching
  * remove duplicate code

I will rebase and add some js code so that the post.topanswers domain is not hardcoded.