### PR TITLE
Explicitly sort in "phone" directory order

### DIFF
--- a/generate-hashes.php
+++ b/generate-hashes.php
@@ -1,7 +1,7 @@
 <?php
-exec("find -L get/lib -maxdepth 19 -type f \( -name '*.js' -o -name '*.css' \) | sort -t '\n'",$files);
-exec("find -L get/fonts -maxdepth 19 -type f \( -name '*.js' -o -name '*.css' \) | sort -t '\n'",$files);
-exec("find -L get -type d \( -path get/lib -o -path get/fonts \) -prune -o \( -name '*.js' -o -name '*.css' \) -type f -print | sort -t '\n'",$files);
+exec("find -L get/lib -maxdepth 19 -type f \( -name '*.js' -o -name '*.css' \) | sort -fdt '\n'",$files);
+exec("find -L get/fonts -maxdepth 19 -type f \( -name '*.js' -o -name '*.css' \) | sort -fdt '\n'",$files);
+exec("find -L get -type d \( -path get/lib -o -path get/fonts \) -prune -o \( -name '*.js' -o -name '*.css' \) -type f -print | sort -fdt '\n'",$files);
 $files = array_map(function($f){ return '/'.substr($f,4); },$files);
 
 foreach($files as $file) {


### PR DESCRIPTION
and also fold lowercase characters into the equivalent uppercase characters.

When I run `generate-hashes.php` with these options, the files in hash.php and require.config.js stay in their current order.
