### PR TITLE
Update postgres container

### DIFF
--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -4,4 +4,4 @@ COPY ./docker/postgres/dbInit/* /docker-entrypoint-initdb.d/
 COPY seeddb /docker-entrypoint-initdb.d/01_seeddb.sh
 RUN sed -i "s/ seed/ postgres/" /docker-entrypoint-initdb.d/01_seeddb.sh
 
-COPY ./sql /var/lib/postgresql/git/sql/
+COPY sql /docker-entrypoint-initdb.d/sql/

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,4 +1,11 @@
-FROM postgres:11.8-alpine
+FROM postgres:11.8
+
+RUN apt-get update \
+  && apt-get install -y \
+  postgresql-plperl-$PG_MAJOR=$PG_VERSION \
+  postgresql-plpython-$PG_MAJOR=$PG_VERSION \
+  postgresql-pltcl-$PG_MAJOR=$PG_VERSION \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY ./docker/postgres/dbInit/* /docker-entrypoint-initdb.d/
 COPY seeddb /docker-entrypoint-initdb.d/01_seeddb.sh

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -3,5 +3,6 @@ FROM postgres:11.8-alpine
 COPY ./docker/postgres/dbInit/* /docker-entrypoint-initdb.d/
 COPY seeddb /docker-entrypoint-initdb.d/01_seeddb.sh
 RUN sed -i "s/ seed/ postgres/" /docker-entrypoint-initdb.d/01_seeddb.sh
+RUN sed -i "s_sql/_/docker-entrypoint-initdb.d/sql/_" /docker-entrypoint-initdb.d/01_seeddb.sh
 
 COPY sql /docker-entrypoint-initdb.d/sql/


### PR DESCRIPTION
@jackdouglas How do you feel about using an environment variable to specify path of the SQL files? `sed` is not very readable, but with environment variables it can be straightforward?

```
ENV SQL_SCRIPTS_DIR     /dockerinit....
```

That way if you ever change your mind to change where the SQL files are located or change the path in the seeddb file, the Dockerfile will still continue to work?

This would require though that the same environment variable name (SQL_SCRIPTS_DIR) is used.